### PR TITLE
feat: update ui_host for posthog

### DIFF
--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -10,7 +10,8 @@ import { PostHogProvider as PHProvider } from 'posthog-js/react'
 export function PostHogProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY as string, {
-      api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST || 'https://us.i.posthog.com',
+      api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST || 'https://eu.i.posthog.com',
+      ui_host: 'https://eu.i.posthog.com',
       person_profiles: 'identified_only', // or 'always' to create profiles for anonymous users as well
       capture_pageview: false // Disable automatic pageview capture, as we capture manually
     })


### PR DESCRIPTION
This pull request includes a change to the `PostHogProvider` configuration to update the API host and add a UI host.

Configuration updates:

* [`app/providers.tsx`](diffhunk://#diff-9f8e69af32baa71de3880fddc9fc0ae3a20f6c38069acc10760de7dc8dc48da0L13-R14): Changed the `api_host` from `https://us.i.posthog.com` to `https://eu.i.posthog.com` and added `ui_host` with the value `https://eu.i.posthog.com`.